### PR TITLE
Shrink PDF size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ booklayout/ebook.pdf: booklayout/ebook.tex booklayout/letterbook.tex booklayout/
 booklayout/ebook.pdf: $(LYS:%.ly=PDF/letter/%.pdf)
 booklayout/toplevel.pdf: $(foreach f,metrical first gospel children,booklayout/$f_insert.tex)
 
-ebook: booklayout/ebook.pdf
+ebook: booklayout/ebook-shrunk.pdf
 
 booklayout/metrical_insert.tex: booklayout/index.meter
 	@echo "[ INDEX ] $@"

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,10 @@ booklayout/%_insert.tex: $$(TXTS)
 	@echo "[ INDEX ] $@"
 	scripts/make_alpha_index.pl $^ > $@
 
-book: cover booklayout/toplevel.pdf
+%-shrunk.pdf: %.pdf
+	extractpdfmark $< | gs -q -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -dPDFDontUseFontObjectNum -dPrinted=false -sOutputFile=$@ $< -
+
+book: cover booklayout/toplevel-shrunk.pdf
 
 COVERS += booklayout/cover-paperback.pdf
 COVERS += booklayout/cover-coilbound.pdf

--- a/scripts/make_index.pl
+++ b/scripts/make_index.pl
@@ -51,7 +51,7 @@ print
         a({ -href => "http://www.lilypond.org/" }, "LilyPond") . ",",
         "and source files are",
         a({ -href => "https://github.com/kulp/eog" }, "available on GitHub") . "."),
-    p("A", a({ -href => 'booklayout/ebook.pdf' }, "PDF optimized for use with e-readers"), "is available."),
+    p("A", a({ -href => 'booklayout/ebook-shrunk.pdf' }, "PDF optimized for use with e-readers"), "is available."),
     p("For information on obtaining these hymns in various print formats, see", a({ -href => 'order' }, "the order page.")),
     p("Playlists for all available MP3s:", map { a({ -href => "$_" }, $_), " " } @lists),
     table({ -class => "sortable", -id => "main" },


### PR DESCRIPTION
[`extractpdfmark`](https://github.com/trueroad/extractpdfmark) can shrink file sizes significantly (>19MiB becomes <6MiB).

- [ ] Keep hyperlinks working in shrunken files