### PR TITLE
Make updates for Lilypond 2.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,14 +287,12 @@ CLOBBERFILES += $(LYS:%.ly=PDF/*/%.$(HEADER_BRACES))
 # PDF rule also creates header files (wanted to do it with MIDI rule but no
 # header files were dumped when there were no active `\layout{ }` blocks)
 PDF/%.pdf $(HEADER_PATTERNS): LYOPTS += --header=$(HEADER_BRACES)
-PDF/%.pdf $(HEADER_PATTERNS): LYOPTS += --define-default=include-settings=variants/PDF-settings.ily
 PDF/%.pdf $(HEADER_PATTERNS): LYOPTS += --pdf
 PDF/%.pdf $(HEADER_PATTERNS): src/$$(*F).ly
 	@mkdir -p $(@D)
 	@echo "[ PDF ] $*.pdf"
 	$(LILYPOND) $(LYOPTS) --include=$(CURDIR)/variants/PDF/$(*D) --output=PDF/$* $<
 
-SVG/%.svg: LYOPTS += --define-default=include-settings=variants/SVG-settings.ily
 SVG/%.svg: LYOPTS += --svg
 SVG/%.svg: src/$$(*F).ly
 	@mkdir -p $(@D)
@@ -323,7 +321,6 @@ SVG/offline/index.html: scripts/make_svg_index.pl scripts/svg.css $(SVGS)
 	$< $(filter %.svg,$^) > $@
 	ln -f scripts/svg.css $(@D)/
 
-MIDI/%.midi: LYOPTS += --define-default=include-settings=variants/MIDI-settings.ily
 MIDI/%.midi: LYOPTS += --define-default=no-print-pages
 MIDI/%.midi: LYOPTS += --define-default=eog-midi-permitted
 MIDI/%.midi: src/$$(*F).ly

--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,7 @@ SVG/offline/index.html: scripts/make_svg_index.pl scripts/svg.css $(SVGS)
 
 MIDI/%.midi: LYOPTS += --define-default=include-settings=variants/MIDI-settings.ily
 MIDI/%.midi: LYOPTS += --define-default=no-print-pages
+MIDI/%.midi: LYOPTS += --define-default=eog-midi-permitted
 MIDI/%.midi: src/$$(*F).ly
 	@mkdir -p $(@D)
 	@echo "[ MIDI ] $*.midi"

--- a/src/EOG037.ly
+++ b/src/EOG037.ly
@@ -178,6 +178,7 @@ For I for -- get so soon;
 The ear -- ly dew of morn -- ing
 Has passed a -- way at noon.
 
+\eogbreak
 \Refrain
 
 }

--- a/src/EOG067.ly
+++ b/src/EOG067.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 191." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 191." } }
   \include "override/override-EOG067.ily"
 }
 
@@ -176,6 +176,6 @@ Hap -- py home to which we go!
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG071.ly
+++ b/src/EOG071.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 5." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 5." } }
   \include "override/override-EOG071.ily"
 }
 
@@ -175,6 +175,6 @@ God is love, God is love.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG076.ly
+++ b/src/EOG076.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 6." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 6." } }
   \include "override/override-EOG076.ily"
 }
 
@@ -182,6 +182,6 @@ wordsF = \markuplist {
   \vspace #1
 } } }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG082.ly
+++ b/src/EOG082.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 34." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 34." } }
   \include "override/override-EOG082.ily"
 }
 
@@ -175,6 +175,6 @@ Says, “Sin -- ner, I am thine!”
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG083.ly
+++ b/src/EOG083.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 349." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 349." } }
   \include "override/override-EOG083.ily"
 }
 
@@ -233,6 +233,6 @@ In the Sav -- iour’s \markup{ name.{\super{★}}}
 
 \include "score-EOG083.ily"
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG088.ly
+++ b/src/EOG088.ly
@@ -2,7 +2,7 @@
 \paper {
   \include "common/paper.ily"
   ragged-last-bottom = ##t % keep markup verses from clinging to bottom of page
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 3 in Supplement." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 3 in Supplement." } }
   \include "override/override-EOG088.ily"
 }
 
@@ -207,6 +207,6 @@ wordsH = \markuplist {
   \vspace #3
 } } }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG089.ly
+++ b/src/EOG089.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 64." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 64." } }
   \include "override/override-EOG089.ily"
 }
 
@@ -217,6 +217,6 @@ wordsE = \markuplist {
   \null
 } \vspace #1 } }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG102.ly
+++ b/src/EOG102.ly
@@ -241,7 +241,7 @@ Be in time!
 segnoWords = \lyricmode {
 
 { \repeat unfold 32 { \skip 4 } }
-\override LyricText #'font-shape = #'italic
+\override LyricText.font-shape = #'italic
 D.S. find no o -- pen gate,
 And your cry be just too late,
 Be in time!
@@ -360,6 +360,6 @@ musicDS = \context ChoirStaff <<
 
 \include "score-EOG102.ily"
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG102.ly
+++ b/src/EOG102.ly
@@ -320,7 +320,6 @@ music = \context ChoirStaff <<
       \context Lyrics = three \lyricsto sopranos \wordsC
       \context Lyrics = four  \lyricsto sopranos \wordsD
     >>
-    \new Lyrics \with { alignAboveContext = men } \lyricsto sopranos \segnoWords
     \context Staff = men <<
       \set Staff.autoBeaming = ##f
       \clef bass
@@ -330,6 +329,7 @@ music = \context ChoirStaff <<
       \context Voice = tenorsSecond { \voiceOne << \notesTenorSecond >> }
       \context Voice = bassesSecond { \voiceTwo << \notesBassSecond >> }
     >>
+    \new Lyrics \with { alignAboveContext = men } \lyricsto sopranos \segnoWords
     \new Lyrics \with { alignAboveContext = men } \lyricsto tenors \underWords
   >>
 

--- a/src/EOG116.ly
+++ b/src/EOG116.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 131." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 131." } }
   \include "override/override-EOG116.ily"
 }
 
@@ -172,6 +172,6 @@ wordsE = \markuplist {
 } } }
 
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG123.ly
+++ b/src/EOG123.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 7." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 7." } }
   \include "override/override-EOG123.ily"
 }
 
@@ -153,6 +153,6 @@ For light di -- vine He’s made us meet.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG144.ly
+++ b/src/EOG144.ly
@@ -2,7 +2,7 @@
 \paper {
   \include "common/paper.ily"
   ragged-last-bottom = ##t
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tunes: No. 164, No. 4 in Supplement." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tunes: No. 164, No. 4 in Supplement." } }
   \include "override/override-EOG144.ily"
 }
 
@@ -188,6 +188,6 @@ In ev -- ’ry -- thing con -- formed to Thee!
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG158.ly
+++ b/src/EOG158.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 321." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 321." } }
   \include "override/override-EOG158.ily"
 }
 
@@ -171,6 +171,6 @@ In sing -- ing still His grace.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG163.ly
+++ b/src/EOG163.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tunes: No.’s 190, 191, 291." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tunes: No.’s 190, 191, 291." } }
   \include "override/override-EOG163.ily"
 }
 
@@ -146,6 +146,6 @@ Take Thy wait -- ing peo -- ple home.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG164.ly
+++ b/src/EOG164.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tunes: No.’s 144, 248." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tunes: No.’s 144, 248." } }
   \include "override/override-EOG164.ily"
 }
 
@@ -172,6 +172,6 @@ To fol -- low, serve and wait for Thee. %{<HIDE%}
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG166.ly
+++ b/src/EOG166.ly
@@ -2,7 +2,7 @@
 \paper {
   \include "common/paper.ily"
   systems-per-page = ##f
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 270." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 270." } }
   \include "override/override-EOG166.ily"
 }
 
@@ -161,6 +161,6 @@ wordsE = \markuplist {
   \vspace #1
 } } }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG181.ly
+++ b/src/EOG181.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 82." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 82." } }
   \include "override/override-EOG181.ily"
 }
 
@@ -161,6 +161,6 @@ We see Thee face to face.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG182.ly
+++ b/src/EOG182.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 155." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 155." } }
   \include "override/override-EOG182.ily"
 }
 
@@ -176,6 +176,6 @@ There shall I dwell with God.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG189.ly
+++ b/src/EOG189.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 183." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 183." } }
   \include "override/override-EOG189.ily"
 }
 
@@ -161,6 +161,6 @@ The one e -- ter -- nal song.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG190.ly
+++ b/src/EOG190.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 191." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 191." } }
   \include "override/override-EOG190.ily"
 }
 
@@ -161,6 +161,6 @@ Let Thy love, Lord, keep us nigh.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG191.ly
+++ b/src/EOG191.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tunes: No.’s 163, 190, 291." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tunes: No.’s 163, 190, 291." } }
   \include "override/override-EOG191.ily"
 
 }
@@ -172,6 +172,6 @@ Ev -- er on Thy house -- hold shine. %{<HIDE%}
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG195.ly
+++ b/src/EOG195.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 150." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 150." } }
   \include "override/override-EOG195.ily"
 }
 
@@ -175,6 +175,6 @@ How oft re -- peat be -- fore the throne,
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG196.ly
+++ b/src/EOG196.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 155." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 155." } }
   \include "override/override-EOG196.ily"
 }
 
@@ -166,6 +166,6 @@ And His blest im -- age bear.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG212.ly
+++ b/src/EOG212.ly
@@ -15,7 +15,7 @@
 
 dualTime = #(define-music-function (parser location num1 num2 denom) (string? string? string?) #{
     \once\override Staff.TimeSignature.stencil = #(dual-time num1 num2 denom)
-    \once\revert TimeSignature #'break-visibility
+    \once\revert TimeSignature.break-visibility
 #})
 
 \header{
@@ -198,6 +198,6 @@ When Je -- sus re -- ceives “His own.”
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG281.ly
+++ b/src/EOG281.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 6 in Supplement." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 6 in Supplement." } }
   \include "override/override-EOG281.ily"
 }
 
@@ -173,6 +173,6 @@ In Thine e -- ter -- nal glo -- ry!
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG307.ly
+++ b/src/EOG307.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 40." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 40." } }
   \include "override/override-EOG307.ily"
 }
 
@@ -186,6 +186,6 @@ Or Je -- sus Christ in glo -- ry see.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG308.ly
+++ b/src/EOG308.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 155." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 155." } }
   \include "override/override-EOG308.ily"
 }
 
@@ -166,6 +166,6 @@ Be -- cause He loved me so.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG329.ly
+++ b/src/EOG329.ly
@@ -1,7 +1,7 @@
 \include "common/global.ily"
 \paper {
   \include "common/paper.ily"
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tune: No. 328." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tune: No. 328." } }
   \include "override/override-EOG329.ily"
 }
 
@@ -200,6 +200,6 @@ wordsE = \markuplist {
   \vspace #1
 } }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG339.ly
+++ b/src/EOG339.ly
@@ -2,7 +2,7 @@
 \paper {
   \include "common/paper.ily"
   ragged-last-bottom = ##t
-  oddFooterMarkup = \markup { \fill-line { \on-the-fly \first-page "Alternate tunes: No.’s 155 and 308." } }
+  oddFooterMarkup = \markup { \fill-line { \if \on-first-page "Alternate tunes: No.’s 155 and 308." } }
   \include "override/override-EOG339.ily"
 }
 
@@ -213,6 +213,6 @@ Of Je -- sus and His love.
   } #}))
 }
 
-\version "2.22.0"  % necessary for upgrading to future LilyPond versions.
+\version "2.24.0"  % necessary for upgrading to future LilyPond versions.
 
 % vi:set et ts=2 sw=2 ai nocindent syntax=lilypond:

--- a/src/EOG378.ly
+++ b/src/EOG378.ly
@@ -111,7 +111,7 @@ wordsA = \lyricmode {
 \set stanza = "1."
 
 The Fa -- ther, from e -- ter -- ni -- ty, \bar "."
-Chose us, O Je -- sus Christ, in Thee, \bar "."
+Chose us, O Je -- sus Christ, in Thee, \bar "." \eogbreak
 In Thee, His well -- be -- lov -- ed; \bar "."
 And we, as giv’n to Thee— Thy bride, \bar "."
 In Thee, Lord Je -- sus, can con -- fide; \bar "."

--- a/variants/MIDI-settings.ily
+++ b/variants/MIDI-settings.ily
@@ -1,1 +1,0 @@
-#(ly:add-option 'eog-midi-permitted #t "True since MIDI should be emitted") 

--- a/variants/PDF-settings.ily
+++ b/variants/PDF-settings.ily
@@ -1,1 +1,0 @@
-#(ly:add-option 'eog-midi-permitted #f "False since no MIDI should be emitted") 

--- a/variants/PDF/eogsized/common/layout.ily
+++ b/variants/PDF/eogsized/common/layout.ily
@@ -17,5 +17,4 @@
     \Voice
     % Make stem direction follow melody
     \consists "Melody_engraver"
-    \override Stem.neutral-direction = #'()
 }

--- a/variants/PDF/eogsized/common/paper.ily
+++ b/variants/PDF/eogsized/common/paper.ily
@@ -62,5 +62,5 @@ bookTitleMarkup = \markup { }
 oddHeaderMarkup = \markup { }
 evenHeaderMarkup = \markup
 \fill-line {
-  \on-the-fly #not-part-first-page \lower #3.5 \huge \larger \larger \bold \fromproperty #'header:title
+  \unless \on-first-page-of-part \lower #3.5 \huge \larger \larger \bold \fromproperty #'header:title
 }

--- a/variants/PDF/eogsized/override/override-EOG037.ily
+++ b/variants/PDF/eogsized/override/override-EOG037.ily
@@ -1,3 +1,0 @@
-page-count = 1
-system-system-spacing.padding = 0
-system-system-spacing.basic-distance = 0

--- a/variants/PDF/eogsized/override/override-EOG378.ily
+++ b/variants/PDF/eogsized/override/override-EOG378.ily
@@ -1,5 +1,3 @@
 page-count = 1
 system-system-spacing.padding = 0
 system-system-spacing.basic-distance = 0
-markup-system-spacing.padding = 0
-markup-system-spacing.basic-distance = 0

--- a/variants/PDF/letter/common/layout.ily
+++ b/variants/PDF/letter/common/layout.ily
@@ -19,5 +19,4 @@
     \Voice
     % Make stem direction follow melody
     \consists "Melody_engraver"
-    \override Stem.neutral-direction = #'()
 }

--- a/variants/PDF/letter/common/paper.ily
+++ b/variants/PDF/letter/common/paper.ily
@@ -60,6 +60,6 @@ bookTitleMarkup = \markup { }
 oddHeaderMarkup = \markup
 \fill-line {
   " "
-  \on-the-fly #not-part-first-page \fromproperty #'header:title
+  \unless \on-first-page-of-part \fromproperty #'header:title
 }
 %% evenHeaderMarkup inherits the value of oddHeaderMarkup

--- a/variants/SVG-settings.ily
+++ b/variants/SVG-settings.ily
@@ -1,1 +1,0 @@
-#(ly:add-option 'eog-midi-permitted #f "False since no MIDI should be emitted") 

--- a/variants/SVG/online/common/layout.ily
+++ b/variants/SVG/online/common/layout.ily
@@ -17,5 +17,4 @@
     \Voice
     % Make stem direction follow melody
     \consists "Melody_engraver"
-    \override Stem.neutral-direction = #'()
 }


### PR DESCRIPTION
[Lilypond 2.24.1 uses Guile 2.2](https://lilypond.org/doc/v2.24/Documentation/changes/index.html), which appears to be stricter about some things.

- [x] `make -j8 book SKIP_SPELLCHECK=1 LILYPOND=lilypond`
- [x] `make svg midi pdfs mp3`