### PR TITLE
Use hanging quotes in indices

### DIFF
--- a/booklayout/indices.tex
+++ b/booklayout/indices.tex
@@ -6,6 +6,9 @@
 \setlength\partopsep{4pt plus \fill}
 \setlength\headheight{24pt}
 
+% See https://tex.stackexchange.com/a/587488 for '\lllap':
+\newcommand{\lllap}[1]{\makebox[0pt][r]{#1}}
+
 \pagestyle{fancy}
 \fancyhf{}
 

--- a/booklayout/indices.tex
+++ b/booklayout/indices.tex
@@ -25,7 +25,7 @@
 \hypertarget{firstlinesindex}{}
 \fancyhead[C]{\large\textsc{Index of First Lines}}
 \renewcommand{\headrulewidth}{0.4pt}
-\setlength{\columnsep}{12pt}
+\setlength{\columnsep}{14pt}
 \begin{multicols}{2}
 {\small
 \setlength\baselineskip{10pt minus 1pt}

--- a/scripts/make_alpha_index.pl
+++ b/scripts/make_alpha_index.pl
@@ -34,6 +34,7 @@ sub compute_length {
 # Schola (lualatex with that font works; tectonic with the default font works).
 sub fix_chars {
     local $_ = shift;
+    s/^“/\\lllap{``}/;
     s/“/``/g;
     s/”/''/g;
     s/‘/`/g;
@@ -54,8 +55,8 @@ sub add {
     # Translate explicit quotes back into implicit quotes; this is a workaround
     # for tectonic with TeX Gyre Schola (lualatex with that font works;
     # tectonic with the default font works).
-    $_ = fix_chars($_);
-    push @list, [ $_, $i ] unless $uniq{"$_/$i"}++;
+    my $new = fix_chars($_);
+    push @list, [ $_, $i, $new ] unless $uniq{"$_/$i"}++;
 }
 
 for my $file (@ARGV) {
@@ -78,7 +79,7 @@ my $last_title = qr/^$/; # unmatchable to begin with
 for (sort dictionary_order @list) {
     my ($letter) = $_->[0] =~ /(\w)/;
     print qq(\\smallbreak{\\centering\\textbf{\\textemdash{}\u$letter\\textemdash{}}\\par}\\nopagebreak\n\n) if $letter ne $last_letter;
-    my $title = $_->[0];
+    my $title = $_->[2];
     $title =~ s/ \.\.\.$//; # suppress ellipsis dots that interfere with \dotfill
     # Suppress titles that are merely suffixes (let the prefix just emitted cover both)
     printf qq(\\hyperlink{EOG%03d}{%s\\dotfill{}%s}\n\n), $_->[1], $title, $_->[1] unless $title =~ /^$last_title/;

--- a/scripts/make_metrical_index.pl
+++ b/scripts/make_metrical_index.pl
@@ -44,6 +44,7 @@ sub munge {
 # Schola (lualatex with that font works; tectonic with the default font works).
 sub fix_chars {
     local $_ = shift;
+    s/^“/\\lllap{``}/;
     s/“/``/g;
     s/”/''/g;
     s/‘/`/g;


### PR DESCRIPTION
I use `\lllap` from https://tex.stackexchange.com/a/587488 to implement hanging quotation marks as shown below.

```bash
mutool convert -F png booklayout/toplevel.pdf 351
convert out-0001.png -crop 100%x25%+0+100 cropped.png
```

# Before
![image](https://user-images.githubusercontent.com/74288/226773183-d3bf5791-0d0d-409c-a9ff-3420d0bfc0d3.png)

# After
![image](https://user-images.githubusercontent.com/74288/226773215-d1f452f4-3ee3-483d-a5ce-7e3aeee8fce3.png)