### PR TITLE
Correct font selection under Tectonic

### DIFF
--- a/booklayout/toplevel.tex
+++ b/booklayout/toplevel.tex
@@ -12,6 +12,14 @@
 \else
   % --------------- XeLaTeX, tectonic or LuaLaTeX
   \usepackage{fontspec}
+  \defaultfontfeatures{Ligatures=TeX}
+  % From https://github.com/tectonic-typesetting/tectonic/issues/372#issuecomment-488268212
+  \setmainfont{texgyreschola-regular.otf}[
+      Ligatures = TeX,
+      BoldFont = texgyreschola-bold.otf,
+      ItalicFont = texgyreschola-italic.otf,
+      BoldItalicFont = texgyreschola-bolditalic.otf,
+  ]
 \fi
 % ---------------
 
@@ -30,15 +38,6 @@
     colorlinks=false,
     pageanchor=false
 }
-
-\defaultfontfeatures{Ligatures=TeX}
-% From https://github.com/tectonic-typesetting/tectonic/issues/372#issuecomment-488268212
-\setmainfont{texgyreschola-regular.otf}[
-    Ligatures = TeX,
-    BoldFont = texgyreschola-bold.otf,
-    ItalicFont = texgyreschola-italic.otf,
-    BoldItalicFont = texgyreschola-bolditalic.otf,
-]
 
 \setlength{\parindent}{20pt}
 \setlength{\parskip}{10pt}

--- a/booklayout/toplevel.tex
+++ b/booklayout/toplevel.tex
@@ -1,16 +1,28 @@
 \documentclass{book}
 \usepackage[tmargin=0.75in,bmargin=0.4in,inner=.75in,outer=.5in,paperwidth=6in,paperheight=9in]{geometry}
 
+% From https://github.com/tectonic-typesetting/tectonic/issues/1026#issuecomment-1517350439
+% --------------- PDFLaTeX, XeLaTeX or LuaLaTeX ?
+\usepackage{iftex}
+\ifPDFTeX
+  % --------------- PDFLaTeX or LaTeX
+  \usepackage[utf8]{inputenc}
+  \usepackage[T1]{fontenc}
+  \usepackage{tgschola}
+\else
+  % --------------- XeLaTeX, tectonic or LuaLaTeX
+  \usepackage{fontspec}
+\fi
+% ---------------
+
 \usepackage{afterpage}
 \usepackage{cabin}
 \usepackage{fancyhdr}
-\usepackage[T1]{fontenc}
 \usepackage{graphicx}
 \usepackage[hidelinks]{hyperref}
 \usepackage[final]{microtype}
 \usepackage{multicol}
 \usepackage{nopageno}
-\usepackage{tgschola}
 
 \hypersetup{
     pdftitle={Echoes of Grace Hymn Book},
@@ -20,6 +32,13 @@
 }
 
 \defaultfontfeatures{Ligatures=TeX}
+% From https://github.com/tectonic-typesetting/tectonic/issues/372#issuecomment-488268212
+\setmainfont{texgyreschola-regular.otf}[
+    Ligatures = TeX,
+    BoldFont = texgyreschola-bold.otf,
+    ItalicFont = texgyreschola-italic.otf,
+    BoldItalicFont = texgyreschola-bolditalic.otf,
+]
 
 \setlength{\parindent}{20pt}
 \setlength{\parskip}{10pt}


### PR DESCRIPTION
An ß in "Laßt mich geh'n" was becoming "SS" due to my use of font handling methods that were inappropriate for Tectonic / XeTeX.

This belongs with a4dbd6e5cffd6ed980cd02968b7a5a4850fd7b66.

This effectively reverts 7ce6e30b6a0a2375f5097d483e2bcd05b4bb9695.

See also:

- https://github.com/tectonic-typesetting/tectonic/issues/372
- https://github.com/tectonic-typesetting/tectonic/issues/1026#issuecomment-1517350439

- [x] Test with `tectonic`
- [x] Test with `lualatex`
- [x] Test with `xetex`