### PR TITLE
Build PDFs via GitHub actions

### DIFF
--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -30,3 +30,7 @@ jobs:
             --workdir ${{ github.workspace }}
           image: my-lilydock:${{ env.LILYPOND_VERSION }}
           run: make --environment-overrides pdf
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pdfs
+          path: PDF/*/*.pdf

--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -10,6 +10,7 @@ on:
 env:
   MAKEFLAGS: --jobs=4
   LILYPOND_VERSION: 2.24.1
+  VARIANTS_PDF: eogsized
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
 env:
+  MAKEFLAGS: --jobs=4
   LILYPOND_VERSION: 2.24.1
 jobs:
   build:

--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -1,0 +1,32 @@
+---
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+env:
+  LILYPOND_VERSION: 2.24.1
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          build-args: LILYPOND_VERSION=${{ env.LILYPOND_VERSION }}
+          tags: my-lilydock:${{ env.LILYPOND_VERSION }}
+      - name: Build PDFs
+        uses: addnab/docker-run-action@v3
+        with:
+          options: |
+            --volume ${{ github.workspace }}:${{ github.workspace }}
+            --workdir ${{ github.workspace }}
+          image: my-lilydock:${{ env.LILYPOND_VERSION }}
+          run: make --environment-overrides pdf

--- a/Makefile
+++ b/Makefile
@@ -35,17 +35,7 @@ PRIMARY_FILE_COUNT = 379
 TOTAL_FILE_COUNT = 387
 TOTAL_PAGE_COUNT = 358 # for toplevel
 
-# Fix lilypond version at 2.20.0 until an issue with EOG302 markup verses is
-# understood.
-LILYPOND_VERSION = 2.20.0
-DOCKER_IMAGE_VARIANT =# empty, except for overrides
-DOCKER_IMAGE = jeandeaual/lilypond:$(LILYPOND_VERSION)$(DOCKER_IMAGE_VARIANT)
-LILYPOND ?= docker run --volume $(CURDIR):$(CURDIR) --workdir $(CURDIR) $(DOCKER_IMAGE) lilypond
-
-# Use the `-fonts` variant (though larger) for the Unicode star in EOG083.
-# Avoid using the `-fonts` variant in general, because (at least at version
-# 2.20.0) it takes a very long time to run font configuration.
-%/EOG083.pdf: DOCKER_IMAGE_VARIANT = -fonts
+LILYPOND ?= lilypond
 
 space :=#
 space +=#

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ LILYPOND ?= docker run --volume $(CURDIR):$(CURDIR) --workdir $(CURDIR) $(DOCKER
 space :=#
 space +=#
 comma :=,
-HEADER_BRACES = {$(subst $(space),$(comma),$(HEADERS))}
 HEADER_PATTERNS = $(foreach h,$(HEADERS),PDF/%.$h)
 
 LYOPTS += --loglevel=WARNING
@@ -283,10 +282,10 @@ override-%.ily:
 	touch $@
 
 CLOBBERFILES += $(PDFS) $(SVGS) $(WAVS) $(MIDIS) $(MP3S)
-CLOBBERFILES += $(LYS:%.ly=PDF/*/%.$(HEADER_BRACES))
+CLOBBERFILES += $(foreach h,$(HEADERS),$(LYS:%.ly=PDF/*/%.$h))
 # PDF rule also creates header files (wanted to do it with MIDI rule but no
 # header files were dumped when there were no active `\layout{ }` blocks)
-PDF/%.pdf $(HEADER_PATTERNS): LYOPTS += --header=$(HEADER_BRACES)
+PDF/%.pdf $(HEADER_PATTERNS): LYOPTS += $(HEADERS:%=--header=%)
 PDF/%.pdf $(HEADER_PATTERNS): LYOPTS += --pdf
 PDF/%.pdf $(HEADER_PATTERNS): src/$$(*F).ly
 	@mkdir -p $(@D)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+ARG LILYPOND_VERSION=2.24.1
+
+FROM jeandeaual/lilypond:$LILYPOND_VERSION as lilypond
+
+FROM debian:bullseye-slim AS base
+COPY --from=lilypond /lilypond /lilypond
+ENV PATH "/lilypond/bin:${PATH}"
+
+RUN apt update
+# See https://github.com/jeandeaual/docker-lilypond/blob/b9ccedde161cf7258844c9b9c5a17d37b64887c9/Dockerfile#L77
+RUN \
+  apt-get install -y --no-install-recommends \
+    ca-certificates \
+    # LilyPond run dependencies
+    libglib2.0-0 \
+    guile-2.2 \
+    libpangoft2-1.0-0 \
+    fontconfig \
+    fonts-dejavu \
+    # Not installed by LilyPond anymore since 2.23.80
+    fonts-urw-base35 \
+    # Remove if / when Ghostscript gets replaced by Cairo
+    ghostscript \
+    # Required when building with --enable-cairo-backend
+    libcairo2 \
+    # For convert-ly
+    python-is-python3 \
+    # LilyPond optional dependencies
+    extractpdfmark \
+    # To transform PDFs (e.g. rotate)
+    qpdf
+
+RUN apt install -y make


### PR DESCRIPTION
In e2a1c60f930dfa8798c332a2b348e12744aafa80 some preliminary support for the [jeandeaual/lilypond] Docker image was added. In the current PR, that support is reverted at the Makefile level, and is reintroduced as a GitHub workflow.

For now, the CI job builds PDFs only.

[jeandeaual/lilypond]: https://github.com/jeandeaual/docker-lilypond