### PR TITLE
Collect minor build changes

### DIFF
--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
   pull_request:
     branches:
       - master

--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           fetch-tags: true
       - name: Build Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:

--- a/transforms.map
+++ b/transforms.map
@@ -273,5 +273,3 @@ what -- e’er	whate’er
 wher -- e’er	where’er
 won -- d’ring	wondering
 wor -- ship -- pers	worshippers
-Can't locate Array/Group.pm in @INC (you may need to install the Array::Group module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.32.1 /usr/local/share/perl/5.32.1 /usr/lib/aarch64-linux-gnu/perl5/5.32 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.32 /usr/share/perl/5.32 /usr/local/lib/site_perl) at scripts/getlyrics.pl line 7.
-BEGIN failed--compilation aborted at scripts/getlyrics.pl line 7.


### PR DESCRIPTION
This also sneaks in a fix for 66314963a3880eb5524a8dab12c709062109c06b in #15.

For some reason, `fetch-depth` in 1ae8f21bcb6f4f813c99c53dd8a6214694e5d9bd appears to be necessary, not only `fetch-tags` in 220522c8bb32257d05bb61ef0c2394730d0349e3, in order for annotated tags to be available for `git describe`.